### PR TITLE
Fix SpellingState for macOS on Swift 3.2

### DIFF
--- a/SwiftyAttributes.podspec
+++ b/SwiftyAttributes.podspec
@@ -2,7 +2,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "SwiftyAttributes"
-  s.version      = "3.1.0"
+  s.version      = "3.2.0"
   s.summary      = "A Swifty API for attributed strings."
 
   s.description  = <<-DESC
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/eddiekaiger/SwiftyAttributes"
   s.license      = { :type => "MIT", :file => "LICENSE" }
   s.author       = { "Eddie Kaiger" => "eddiekaiger@gmail.com" }
-  s.source       = { :git => "https://github.com/eddiekaiger/SwiftyAttributes.git", :tag => "v3.1.0" }
+  s.source       = { :git => "https://github.com/eddiekaiger/SwiftyAttributes.git", :tag => "v3.2.0" }
   
   s.source_files = "SwiftyAttributes/Sources/common/*.swift"
   s.osx.source_files = "SwiftyAttributes/Sources/macOS/*.swift"

--- a/SwiftyAttributes/Sources/macOS/NSAttributedString+macOS.swift
+++ b/SwiftyAttributes/Sources/macOS/NSAttributedString+macOS.swift
@@ -37,7 +37,7 @@ extension NSAttributedString {
      - parameter    state:  A state indicating a spelling or grammar error. See `SpellingState` for possible values.
      - returns:             A new attributed string with the newly added attribute.
      */
-    public func withSpellingState(_ state: SpellingState) -> NSMutableAttributedString {
+    public func withSpellingState(_ state: SwiftyAttributes.SpellingState) -> NSMutableAttributedString {
         return withAttribute(.spellingState(state))
     }
 

--- a/SwiftyAttributes/Sources/macOS/SpellingState.swift
+++ b/SwiftyAttributes/Sources/macOS/SpellingState.swift
@@ -14,32 +14,12 @@ import AppKit
      highlighting portions of the text that are flagged for spelling or grammar issues. 
      This should be used with `Attribute.spellingState`.
  */
-public enum SpellingState: RawRepresentable {
-
-    /// No spelling or grammar indicator.
-    case none
+public enum SpellingState: Int {
 
     /// The spelling error indicator.
-    case spellingFlag
+    case spelling = 1
 
     /// The grammar error indicator.
-    case grammarFlag
-
-    public init?(rawValue: Int) {
-        switch rawValue {
-        case 0: self = .none
-        case NSSpellingStateSpellingFlag: self = .spellingFlag
-        case NSSpellingStateGrammarFlag: self = .grammarFlag
-        default: return nil
-        }
-    }
-
-    public var rawValue: Int {
-        switch self {
-        case .none: return 0
-        case .spellingFlag: return NSSpellingStateSpellingFlag
-        case .grammarFlag: return NSSpellingStateGrammarFlag
-        }
-    }
+    case grammar = 2
 }
 #endif

--- a/SwiftyAttributesTests/NSAttributedString_Tests.swift
+++ b/SwiftyAttributesTests/NSAttributedString_Tests.swift
@@ -263,11 +263,11 @@ class NSAttributedString_Tests: XCTestCase {
     }
 
     func testAttributeAtLocation_spellingState() {
-        let str = "Hello".withSpellingState(.grammarFlag)
+        let str = "Hello".withSpellingState(.grammar)
         let subject = str.attribute(.spellingState, at: 0, effectiveRange: nil)!.value as! SpellingState
         let expected = str.attribute(NSSpellingStateAttributeName, at: 0, effectiveRange: nil) as! Int
         XCTAssertEqual(subject.rawValue, expected)
-        XCTAssertEqual(subject, .grammarFlag)
+        XCTAssertEqual(subject, .grammar)
     }
 
     func testAttributeAtLocation_superscript() {

--- a/SwiftyAttributesTests/SpellingState_Tests.swift
+++ b/SwiftyAttributesTests/SpellingState_Tests.swift
@@ -17,15 +17,9 @@ class SpellingState_Tests: XCTestCase {
     }
 
     func testInit_flags() {
-        XCTAssertEqual(SpellingState(rawValue: NSSpellingStateGrammarFlag)!, .grammarFlag)
-        XCTAssertEqual(SpellingState(rawValue: NSSpellingStateSpellingFlag)!, .spellingFlag)
-        XCTAssertEqual(SpellingState(rawValue: 0)!, .none)
-    }
-
-    func testRawValue() {
-        XCTAssertEqual(SpellingState.grammarFlag.rawValue, NSSpellingStateGrammarFlag)
-        XCTAssertEqual(SpellingState.spellingFlag.rawValue, NSSpellingStateSpellingFlag)
-        XCTAssertEqual(SpellingState.none.rawValue, 0)
+        XCTAssertEqual(SpellingState(rawValue: 2)!, .grammar)
+        XCTAssertEqual(SpellingState(rawValue: 1)!, .spelling)
+        XCTAssertNil(SpellingState(rawValue: 0))
     }
     
 }

--- a/SwiftyAttributesTests/SwiftyAttributes_Tests.swift
+++ b/SwiftyAttributesTests/SwiftyAttributes_Tests.swift
@@ -215,17 +215,9 @@ class SwiftyAttributesTests: XCTestCase {
     }
 
     func testAttribute_spellingState_grammar() {
-        let subject = "Hello".withSpellingState(.grammarFlag)
-        let subject2 = "Hello".attributedString.withSpellingState(.grammarFlag)
-        let expected = NSAttributedString(string: "Hello", attributes: [NSSpellingStateAttributeName: NSSpellingStateGrammarFlag])
-        XCTAssertEqual(subject, expected)
-        XCTAssertEqual(subject2, expected)
-    }
-
-    func testAttribute_spellingState_none() {
-        let subject = "Hello".withSpellingState(.none)
-        let subject2 = "Hello".attributedString.withSpellingState(.none)
-        let expected = NSAttributedString(string: "Hello", attributes: [NSSpellingStateAttributeName: 0])
+        let subject = "Hello".withSpellingState(.grammar)
+        let subject2 = "Hello".attributedString.withSpellingState(.grammar)
+        let expected = NSAttributedString(string: "Hello", attributes: [NSSpellingStateAttributeName: 2])
         XCTAssertEqual(subject, expected)
         XCTAssertEqual(subject2, expected)
     }


### PR DESCRIPTION
Swift 3.2 replaces the `NSSpellingStateSpellingFlag` and `NSSpellingStateGrammarFlag` constants with the enum `NSSpellingState` (`NSAttributedString.SpellingState`) . For macOS apps on Swift 3.2+ to build correctly we will just require `SwiftyAttributes.SpellingState` to be used, which now looks identical to the newly introduced enum on macOS 10.13.