### PR TITLE
Fix instantiating NSMutableAttributeString with attributes on Xcode 10

### DIFF
--- a/SwiftyAttributes.podspec
+++ b/SwiftyAttributes.podspec
@@ -2,7 +2,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "SwiftyAttributes"
-  s.version      = "4.3.0"
+  s.version      = "5.0.0"
   s.summary      = "A Swifty API for attributed strings."
 
   s.description  = <<-DESC

--- a/SwiftyAttributes/Info.plist
+++ b/SwiftyAttributes/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.1.0</string>
+	<string>5.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/SwiftyAttributes/Sources/common/NSAttributedString+SwiftyAttributes.swift
+++ b/SwiftyAttributes/Sources/common/NSAttributedString+SwiftyAttributes.swift
@@ -27,11 +27,11 @@ extension NSAttributedString {
     /**
      Creates a new `NSAttributedString` with the specified attributes.
      
-     - parameter    str:            The string for the new attributed string.
-     - parameter    attributes:     The attributes for the new attributed string.
+     - parameter    str:                The string for the new attributed string.
+     - parameter    swiftyAttributes:   The attributes for the new attributed string.
      */
-    public convenience init(string str: String, attributes: [Attribute]) {
-        self.init(string: str, attributes: dictionary(from: attributes))
+    public convenience init(string str: String, swiftyAttributes attrs: [Attribute]) {
+        self.init(string: str, attributes: dictionary(from: attrs))
     }
 
     /**

--- a/SwiftyAttributesTests/NSAttributedString_Tests.swift
+++ b/SwiftyAttributesTests/NSAttributedString_Tests.swift
@@ -12,7 +12,7 @@ import SwiftyAttributes
 class NSAttributedString_Tests: XCTestCase {
     
     func testInit_withStringAndAttributes() {
-        let subject = NSAttributedString(string: "Hello World", attributes: [.strokeColor(.green), .strokeWidth(3)])
+        let subject = NSAttributedString(string: "Hello World", swiftyAttributes: [.strokeColor(.green), .strokeWidth(3)])
         #if swift(>=4.0)
             let expected = NSAttributedString(string: "Hello World", attributes: [.strokeColor: Color.green, .strokeWidth: 3])
         #else

--- a/SwiftyAttributesTests/NSMutableAttributedString_Tests.swift
+++ b/SwiftyAttributesTests/NSMutableAttributedString_Tests.swift
@@ -10,6 +10,16 @@ import XCTest
 import SwiftyAttributes
 
 class NSMutableAttributedString_Tests: XCTestCase {
+
+    func testInitMutable_withStringAndAttributes() {
+        let subject = NSMutableAttributedString(string: "Hello World", swiftyAttributes: [.strokeColor(.green), .strokeWidth(3)])
+        #if swift(>=4.0)
+        let expected = NSMutableAttributedString(string: "Hello World", attributes: [.strokeColor: Color.green, .strokeWidth: 3])
+        #else
+        let expected = NSMutableAttributedString(string: "Hello World", attributes: [NSStrokeColorAttributeName: Color.green, NSStrokeWidthAttributeName: 3])
+        #endif
+        XCTAssertEqual(subject, expected)
+    }
     
     func testAddAttributes_usingSwiftRange() {
         let subject = "Hello".withTextColor(.orange)


### PR DESCRIPTION
When instantiating an `NSMutableAttributedString` in a target that imports SwiftyAttributes on Xcode 10 the compiler was getting confused on which initializer to use. The convenience initializer added to `NSAttributedString` seems to be throwing the compiler out of whack. This updates argument names to give a clearer distinction and resolves the issue.

See issue #29 for more details.